### PR TITLE
Add suggestion to use babel upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -302,7 +302,7 @@ As mentioned a few times in the past, the core team is reviewing the repository 
      }
    ```
 
-3. Ensure that you have all the babel dependencies to version `^7.0.0` (you may also need to add `"babel-core": "7.0.0-bridge.0"` as a yarn resolution to ensure retro-compatibility)
+3. Ensure that you have all the babel dependencies to version `^7.0.0` (you may also need to add `"babel-core": "7.0.0-bridge.0"` as a yarn resolution to ensure retro-compatibility).  [babel-upgrade](https://github.com/babel/babel-upgrade) makes this easy.
 4. If you have a custom packager configuration via `rn-cli.config.js`, you probably need to update it to work with the updated Metro configuration structure (for full detail refer to Metro's [documentation](https://facebook.github.io/metro/docs/en/configuration)); here are some commonly encountered changes to `rn-cli.config.js`:
 
    ```diff


### PR DESCRIPTION
I couldn't get the upgraded Babel to work by updating my dependencies, finally found `babel-upgrade` and it finally works!  Recommend including this content to potentially save people a lot of time.