### PR TITLE
Add missing breaking change for 0.58

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,26 @@ Thanks to those who gave feedback on during the [release candidate phase](https:
 #### Breaking Changes 💥
 
 - Public methods of components converted to ES6 classes are no longer bound to their component instance. For `ScrollView`, the affected methods are `setNativeProps`, `getScrollResponder`, `getScrollableNode`, `getInnerViewNode`, `scrollTo`, `scrollToEnd`, `scrollWithoutAnimationTo`, and `flashScrollIndicators`. For `CameraRollView`, the affected methods are: `rendererChanged`. For `SwipeableRow`, the affected methods are: `close`. Therefore, it is no longer safe to pass these method by reference as callbacks to functions. Auto-binding methods to component instances was a behaviour of `createReactClass` that we decided to not preserve when switching over to ES6 classes. (you can refer to [this example](https://github.com/react-native-community/react-native-releases/issues/81#issuecomment-459252692))
+- Native Modules in Android now require `@ReactModule` annotations to access `.getNativeModule` method on the `ReactContext`. This is how your updated Native Module should look like:
+
+  ```diff
+  // CustomModule.java
+
+  // ...
+  +  import com.facebook.react.module.annotations.ReactModule;
+
+  +  @ReactModule(name="CustomBridge")
+  public class CustomModule extends ReactContextBaseJavaModule {
+    // ...
+
+    @Override
+    public String getName() {
+        return "CustomBridge";
+    }
+
+    // ...
+  }
+  ```
 
 #### Android specific
 


### PR DESCRIPTION
In [this commit](https://github.com/facebook/react-native/commit/0cd3994f1a4ec1172af840cf5de3dddb1ae9e9c4), the way modules are accessed internally was changed. As such, whenever any userland code tries to access the instance of a Native Module, the app crashes. This is because all such native modules now require a `@ReactModule` annotation at the top which is the public name of the native module.

This was also reported in another repo: https://github.com/oney/react-native-webrtc/issues/575 and fixed like so: https://github.com/oney/react-native-webrtc/commit/8def7d0dc9370934a4d56770d63d742c2a203fea